### PR TITLE
Add Prometheus runtime option to client

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1049,4 +1049,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "00d216b6693daf001a885f3a926898bf36df258f5361858b1c392ed7c26f6503"
+content-hash = "e2ff514898d6cfcb3a219f59c94d40edb4b3e9500a01f4a820ce85fbbf78519c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.4.0"
+version = "1.4.4"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"
@@ -14,6 +14,7 @@ temporalio = "^1.3.0"
 pycryptodome = "^3.15.0"
 google-auth = "^2.19.1"
 sentry-sdk = "^1.29.2"
+pydantic-settings = "2.4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"
@@ -22,7 +23,6 @@ isort = "^5.10.1"
 poethepoet = "^0.16.2"
 pytest-asyncio = "^0.19.0"
 mypy = "^0.971"
-pydantic-settings = "2.4.0"
 
 [tool.poe.tasks]
 format = [{cmd = "black ."}, {cmd = "isort ."}]

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -119,7 +119,7 @@ class Client:
             # Start a task to periodically update rpc_metadata
             asyncio.create_task(Client.update_rpc_metadata_loop(client_opt, rpc_metadata))
 
-        if client_opt.encryption:
+        if client_opt.encryption and client_opt.encryption.key:
             encryption_codec = EncryptionPayloadCodec(client_opt.encryption.key)
             data_converter = dataclasses.replace(
                 data_converter, payload_codec=encryption_codec

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -9,7 +9,11 @@ from temporalio.client import Interceptor, OutboundInterceptor
 from temporalio.common import QueryRejectCondition
 from temporalio.converter import DataConverter, default
 from temporalio.service import TLSConfig, RetryConfig, KeepAliveConfig
-from temporalio.runtime import Runtime
+from temporalio.runtime import (
+    PrometheusConfig,
+    Runtime,
+    TelemetryConfig,
+)
 
 from temporallib.auth import AuthHeaderProvider, AuthOptions, MacaroonAuthOptions, GoogleAuthOptions, KeyPair
 from temporallib.encryption import EncryptionOptions, EncryptionPayloadCodec
@@ -20,17 +24,29 @@ import os
 
 
 class Options(BaseSettings):
-    host: str
-    queue: str
-    namespace: str
+    host: Optional[str] = None
+    queue: Optional[str] = None
+    namespace: Optional[str] = None
     encryption: Optional[EncryptionOptions] = None
-    tls_root_cas: Optional[str]
+    tls_root_cas: Optional[str] = None
     auth: Optional[AuthOptions] = None
+    prometheus_port: Optional[str] = None
 
     class Config:
         env_prefix = 'TEMPORAL_'
 
 Options.model_rebuild()
+
+def _init_runtime_with_prometheus(port: int) -> Runtime:
+    """Create runtime for use with Prometheus metrics.
+
+    Args:
+        port: Port of prometheus.
+
+    Returns:
+        Runtime for temporalio with prometheus.
+    """
+    return Runtime(telemetry=TelemetryConfig(metrics=PrometheusConfig(bind_address=f"0.0.0.0:{port}")))
 
 class Client:
     """
@@ -113,6 +129,9 @@ class Client:
             enc_tls_root_cas = client_opt.tls_root_cas.encode()
             host = client_opt.host.split(":")[0]
             tls = TLSConfig(server_root_ca_cert=enc_tls_root_cas, domain=host)
+
+        if runtime is None and client_opt.prometheus_port:
+            runtime = _init_runtime_with_prometheus(int(client_opt.prometheus_port))
 
         return await TemporalClient.connect(
             client_opt.host,

--- a/temporallib/worker/worker.py
+++ b/temporallib/worker/worker.py
@@ -74,7 +74,7 @@ class Worker(TemporalWorker):
             raise ValueError("task_queue must be provided either as a parameter or an environment variable.")
 
         if worker_opt:
-            if worker_opt.sentry:
+            if worker_opt.sentry and worker_opt.sentry.dsn:
                 interceptors.append(SentryInterceptor())
 
                 before_send = None


### PR DESCRIPTION
## Description

This PR builds on the work done in #15 :
- Enables the Prometheus runtime to be enabled by setting the `TEMPORAL_PROMETHEUS_PORT` environment variable.
- Fixes the Sentry options such that the Sentry SDK is not initialized if the Sentry DSN is set to `""`, and the same thing for `EncryptionOptions`.
- Fixes the `pydantic-settings` dependency which was mistakenly added under the dev dependencies the last time.