### PR TITLE
Authorization Refresh: Set rpc metadata instead of update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.8.2"
+version = "1.8.3"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"

--- a/temporallib/auth/auth.py
+++ b/temporallib/auth/auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Mapping, Optional
 
 import requests
 from macaroonbakery import bakery, httpbakery

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -70,6 +70,7 @@ class Client:
         """
         Reconnects to the Temporal server periodically when the token expires.
         """
+        backoff = self._initial_backoff
         while not self._is_stop_token_refresh:
             try:
                 await self._reconnect()
@@ -146,32 +147,31 @@ class Client:
         if self._runtime is None and client_opt.prometheus_port:
             self._runtime = _init_runtime_with_prometheus(int(client_opt.prometheus_port))
 
-        asyncio.create_task(self.reconnect_loop())
+        self._client = await TemporalClient.connect(
+            self._client_opts.host,
+            namespace=self._client_opts.namespace or os.getenv("TEMPORAL_NAMESPACE") or "default",
+            data_converter=self._data_converter,
+            interceptors=self._interceptors,
+            default_workflow_query_reject_condition=self._default_workflow_query_reject_condition,
+            tls=self._tls,
+            retry_config=self._retry_config,
+            rpc_metadata=self._rpc_metadata,
+            identity=self._identity,
+            lazy=self._lazy,
+            runtime=self._runtime,
+            keep_alive_config=self._keep_alive_config,
+        )
 
-        return await self._reconnect()
+        asyncio.create_task(self.reconnect_loop())
+        
+        return self._client
 
     @classmethod
     async def _reconnect(self):
-        """
-        Internal method to reconnect using the saved parameters.
-        """
-        if self._client_opts:
-            # Refresh the auth headers before reconnecting
-            if self._client_opts.auth:
-                auth_header_provider = AuthHeaderProvider(self._client_opts.auth)
-                self._rpc_metadata.update(auth_header_provider.get_headers())
-            
-            return await TemporalClient.connect(
-                self._client_opts.host,
-                namespace=self._client_opts.namespace or os.getenv("TEMPORAL_NAMESPACE") or "default",
-                data_converter=self._data_converter,
-                interceptors=self._interceptors,
-                default_workflow_query_reject_condition=self._default_workflow_query_reject_condition,
-                tls=self._tls,
-                retry_config=self._retry_config,
-                rpc_metadata=self._rpc_metadata,
-                identity=self._identity,
-                lazy=self._lazy,
-                runtime=self._runtime,
-                keep_alive_config=self._keep_alive_config,
-            )
+        # Refresh the auth headers before reconnecting
+        if self._client_opts.auth:
+            auth_header_provider = AuthHeaderProvider(self._client_opts.auth)
+            self._client.rpc_metadata = {**self._client.rpc_metadata, **auth_header_provider.get_headers()}
+
+        logging.debug("Testing Temporal server connection")
+        await self._client.count_workflows()


### PR DESCRIPTION
## Description

I don't think the current token refresh implementation works correctly given that it mutates the rpc headers instead of overwriting them ([the documentation confirms this is incorrect](https://python.temporal.io/temporalio.client.Client.html#rpc_metadata), as `rpc_metadata` is a decorated property).

This PR modifies the client wrapper to save a copy of the client, and overwrite `rpc_metadata` when new authentication headers every 55 minutes.

## Engineering checklist

- [ ] Documentation updated
- [ ] Have tested the workflow works as expected

