### PR TITLE
add missing import for "Optional" in auth.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.8.0"
+version = "1.8.1"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"

--- a/temporallib/auth/auth.py
+++ b/temporallib/auth/auth.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Mapping, Optional
 
 import requests
 from macaroonbakery import bakery, httpbakery


### PR DESCRIPTION
## Description

Importing GoogleAuthOptions in Python 3.12 results in a Pydantic error:
```bash
pydantic.errors.PydanticUserError: `GoogleAuthOptions` is not fully defined; you should define `Optional`, then call `GoogleAuthOptions.model_rebuild()`.
```
Added import into auth.py and incremented version in pyproject.toml