### PR TITLE
Update sigstore action version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,7 +72,7 @@ jobs:
           path: dist/
 
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v1.2.3
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: |
             ./dist/*.tar.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.8.1"
+version = "1.8.2"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"


### PR DESCRIPTION
## Description

- Updated version of [gh-action-sigstore-python](https://github.com/sigstore/gh-action-sigstore-python). The previous one used a [deprecated version of upload-artifact](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).
- Bumped package version to 1.8.2 to avoid conflicts with previous ones.