### PR TITLE
Decreased time for token refresh

### DIFF
--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -83,7 +83,7 @@ class Client:
                 )
                 await asyncio.sleep(
                     self._token_refresh_interval
-                )  # Refresh tokens every ~55 minutes (OAuth tokens last 60 minutes)
+                )  # Refresh tokens every ~50 minutes (OAuth tokens last 60 minutes)
                 logging.info("Refreshing token and reconnecting to Temporal server...")
             except Exception as e:
                 logging.error(f"Failed to reconnect to Temporal server: {e}")

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import datetime
 import logging
 import os
 from typing import Callable, Iterable, Mapping, Optional, Union
@@ -60,7 +61,7 @@ class Client:
     _is_stop_token_refresh = False
     _initial_backoff = 60
     _max_backoff = 600
-    _token_refresh_interval = 3300
+    _token_refresh_interval = 3000
 
     @classmethod
     def __del__(self):
@@ -73,8 +74,13 @@ class Client:
         """
         while not self._is_stop_token_refresh:
             try:
+                start = datetime.datetime.now()
                 await self._reconnect()
                 backoff = self._initial_backoff
+                end = datetime.datetime.now()
+                logging.info(
+                    f"Token refreshed in {(end - start).total_seconds()} seconds."
+                )
                 await asyncio.sleep(
                     self._token_refresh_interval
                 )  # Refresh tokens every ~55 minutes (OAuth tokens last 60 minutes)


### PR DESCRIPTION
## Description
The GE team was having issues with the long-running workflows. They realized that after some time, their workflows were stuck. I investigated the logs and saw that workflows are stuck after one hour. The error message was like below:

`error: accumulating resources: accumulation err='accumulating resources from '../base': '/var/lib/jenkins/slaves/jenkins-agent-4/workspace/collective-staging-ps5/collective/workflows/crisis24/base' must resolve to a file': recursed accumulation of path '/var/lib/jenkins/slaves/jenkins-agent-4/workspace/collective-staging-ps5/collective/workflows/crisis24/base': no resource matches strategic merge patch "[CronWorkflow.v1alpha1.argoproj.io/crisis24.[noNs]](http://cronworkflow.v1alpha1.argoproj.io/crisis24.%5BnoNs%5D)": no matches for Id [CronWorkflow.v1alpha1.argoproj.io/crisis24.[noNs]](http://cronworkflow.v1alpha1.argoproj.io/crisis24.%5BnoNs%5D); failed to find unique target for patch [CronWorkflow.v1alpha1.argoproj.io/crisis24.[noNs]](http://cronworkflow.v1alpha1.argoproj.io/crisis24.%5BnoNs%5D)`

As we already have token refresh logic in this library, I checked the logs for the workers to see the refresh issues. It turns out that tokens are refreshed every 61-62 minutes rather than the predefined 55 minutes.  However, as GE's workflows run over 60 minutes, the token expires after 60 minutes, and the workflows get stuck.
 
```
prod-temporal-workers-comsys@comsys-bastion-ps6:~$ k logs ge-workflows-worker-0 -c temporal-worker | grep Refreshing
2025-04-11T05:25:50.111Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T06:27:23.580Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T07:28:32.376Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T08:30:02.773Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T09:31:21.381Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T10:32:45.448Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T11:33:57.755Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T12:35:29.530Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
2025-04-11T13:36:48.591Z [temporal-worker] INFO:root:Refreshing token and reconnecting to Temporal server...
```

This PR reduces the token refresh interval to 50 minutes and also logs the time to connect to the server. I also logged the connect time because this is the only part that can take > 1 minute, so we ended up with 62 minutes. 

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [ ] Have tested the workflow works as expected

## Test instructions

<!-- *(optional)* Describe any non-standard test instructions and configuration settings. Delete this section if not applicable. -->

## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->