### PR TITLE
Add disconnect and instance classmethods to Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.8.3"
+version = "1.8.4"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -75,6 +75,11 @@ class Client:
         del self._runtime
 
     @classmethod
+    def instance(self):
+        """Returns the underlying TemporalClient instance."""
+        return self._client
+
+    @classmethod
     async def reconnect_loop(self):
         """
         Reconnects to the Temporal server periodically when the token expires.

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -57,6 +57,7 @@ class Client:
     A class which wraps the :class:`temporalio.client.Client` class with reconnect logic.
     """
 
+    _client: TemporalClient
     _is_stop_token_refresh = False
     _initial_backoff = 60
     _max_backoff = 600
@@ -65,6 +66,13 @@ class Client:
     @classmethod
     def __del__(self):
         self._is_stop_token_refresh = True
+
+    @classmethod
+    def disconnect(self):
+        """Stops the reconnect loop and closes the client."""
+        self._is_stop_token_refresh = True
+        del self._client
+        del self._runtime
 
     @classmethod
     async def reconnect_loop(self):

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -57,7 +57,7 @@ class Client:
     A class which wraps the :class:`temporalio.client.Client` class with reconnect logic.
     """
 
-    _client: TemporalClient
+    _client: TemporalClient = None
     _is_stop_token_refresh = False
     _initial_backoff = 60
     _max_backoff = 600
@@ -75,8 +75,8 @@ class Client:
         del self._runtime
 
     @classmethod
-    def instance(self) -> TemporalClient:
-        """Returns the underlying TemporalClient instance."""
+    def instance(self) -> Optional[TemporalClient]:
+        """Returns the underlying TemporalClient instance, if it exists."""
         return self._client
 
     @classmethod

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -75,7 +75,7 @@ class Client:
         del self._runtime
 
     @classmethod
-    def instance(self):
+    def instance(self) -> TemporalClient:
         """Returns the underlying TemporalClient instance."""
         return self._client
 


### PR DESCRIPTION
## Description

* Sometimes we may want a short-lived Client, or we might need to manually stop a Client to start a new one. The `disconnect` method stops the reconnect loop and destroys the underlying `_client` and `_runtime`.
* Conversely, sometimes we may want to use an existing Client connection within a workflow. The `instance` method returns the underlying Temporal client that can be used to e.g. fetch schedules.

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [x] Have tested the workflow works as expected