### PR TITLE
[WF-92] Enable static code analysis (TIOBE) scans

### DIFF
--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -1,0 +1,28 @@
+# .github/workflows/tiobe-scan.yaml
+name: Tiobe TICS Analysis
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 2 * * 1"
+
+jobs:
+  tics-scan:
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Package coverage for TICS
+        run: |
+          mkdir -p .cover
+
+      - name: Run TICS analysis
+        uses: tiobe/tics-github-action@v3
+        with:
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          mode: qserver
+          project: temporal-lib-py
+          branchdir: .
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true


### PR DESCRIPTION
## Description

Added Static Code Analysis to the repo to run every Monday automatically or by manual trigger.

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [x] Have tested the workflow works as expected

## Test instructions
The workflow can be tested by manual trigger or by automated trigger at 2 UTC every Monday.

## Notes for code reviewers

<!-- *(optional)* Mention any relevant information for code reviewers. Delete this section if not applicable. -->