### PR TITLE
Update pydantic classes to remove deprecated feature

### DIFF
--- a/temporallib/auth/auth.py
+++ b/temporallib/auth/auth.py
@@ -12,7 +12,7 @@ from macaroonbakery import bakery, httpbakery
 from macaroonbakery.bakery import Macaroon, b64decode, macaroon_to_dict
 from macaroonbakery.httpbakery.agent import Agent, AgentInteractor, AuthInfo
 from pydantic import BaseModel, Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class MacaroonAuthOptions(BaseSettings):
@@ -20,9 +20,9 @@ class MacaroonAuthOptions(BaseSettings):
     username: str
     keys: Optional[KeyPair]
 
-    class Config:
-        env_prefix = "TEMPORAL_CANDID_"
-        populate_by_name = True
+    model_config = SettingsConfigDict(
+        env_prefix="TEMPORAL_CANDID_", populate_by_name=True
+    )
 
 
 class GoogleAuthOptions(BaseSettings):
@@ -39,25 +39,23 @@ class GoogleAuthOptions(BaseSettings):
         None, alias="TEMPORAL_OIDC_CLIENT_CERT_URL"
     )
 
-    class Config:
-        env_prefix = "TEMPORAL_OIDC_"
-        populate_by_name = True
+    model_config = SettingsConfigDict(
+        env_prefix="TEMPORAL_OIDC_", populate_by_name=True
+    )
 
 
 class KeyPair(BaseSettings):
     private: str = Field(None, alias="TEMPORAL_CANDID_PRIVATE_KEY")
     public: str = Field(None, alias="TEMPORAL_CANDID_PUBLIC_KEY")
 
-    class Config:
-        populate_by_name = True
+    model_config = SettingsConfigDict(populate_by_name=True)
 
 
 class AuthOptions(BaseSettings):
     config: Optional[Union[MacaroonAuthOptions, GoogleAuthOptions]] = None
     provider: str
 
-    class Config:
-        env_prefix = "TEMPORAL_AUTH_"
+    model_config = SettingsConfigDict(env_prefix="TEMPORAL_AUTH_")
 
 
 class AuthHeaderProvider:

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -6,7 +6,7 @@ import logging
 import os
 from typing import Callable, Iterable, Mapping, Optional, Union
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from temporalio.client import Client as TemporalClient
 from temporalio.client import Interceptor, OutboundInterceptor
 from temporalio.common import QueryRejectCondition
@@ -29,8 +29,7 @@ class Options(BaseSettings):
     auth: Optional[AuthOptions] = None
     prometheus_port: Optional[str] = None
 
-    class Config:
-        env_prefix = "TEMPORAL_"
+    model_config = SettingsConfigDict(env_prefix="TEMPORAL_")
 
 
 Options.model_rebuild()
@@ -171,7 +170,9 @@ class Client:
 
         self._client = await TemporalClient.connect(
             self._client_opts.host,
-            namespace=self._client_opts.namespace or os.getenv("TEMPORAL_NAMESPACE") or "default",
+            namespace=self._client_opts.namespace
+            or os.getenv("TEMPORAL_NAMESPACE")
+            or "default",
             data_converter=self._data_converter,
             interceptors=self._interceptors,
             default_workflow_query_reject_condition=self._default_workflow_query_reject_condition,
@@ -185,7 +186,7 @@ class Client:
         )
 
         asyncio.create_task(self.reconnect_loop())
-        
+
         return self._client
 
     @classmethod
@@ -193,7 +194,10 @@ class Client:
         # Refresh the auth headers before reconnecting
         if self._client_opts.auth:
             auth_header_provider = AuthHeaderProvider(self._client_opts.auth)
-            self._client.rpc_metadata = {**self._client.rpc_metadata, **auth_header_provider.get_headers()}
+            self._client.rpc_metadata = {
+                **self._client.rpc_metadata,
+                **auth_header_provider.get_headers(),
+            }
 
         logging.debug("Testing Temporal server connection")
         await self._client.count_workflows()

--- a/temporallib/encryption/data_converter.py
+++ b/temporallib/encryption/data_converter.py
@@ -2,7 +2,7 @@ import base64
 import binascii
 from typing import Iterable, List, Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from temporalio.api.common.v1 import Payload
 from temporalio.converter import PayloadCodec
 
@@ -13,8 +13,7 @@ class EncryptionOptions(BaseSettings):
     key: Optional[str] = None
     compress: Optional[bool] = False
 
-    class Config:
-        env_prefix = "TEMPORAL_ENCRYPTION_"
+    model_config = SettingsConfigDict(env_prefix="TEMPORAL_ENCRYPTION_")
 
 
 class EncryptionPayloadCodec(PayloadCodec):

--- a/temporallib/worker/sentry_interceptor.py
+++ b/temporallib/worker/sentry_interceptor.py
@@ -1,10 +1,11 @@
 """Temporal client worker Sentry interceptor."""
 
+import os
 from dataclasses import asdict, is_dataclass
 from typing import Any, Optional, Type, Union
 
 from pydantic import validator
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from temporalio import activity, workflow
 from temporalio.worker import (
     ActivityInboundInterceptor,
@@ -30,8 +31,7 @@ class SentryOptions(BaseSettings):
     sample_rate: Optional[float] = 1.0
     redact_params: Optional[bool] = False
 
-    class Config:
-        env_prefix = "TEMPORAL_SENTRY_"
+    model_config = SettingsConfigDict(env_prefix="TEMPORAL_SENTRY_")
 
     @validator("sample_rate", pre=True, always=True)
     def validate_sample_rate(cls, v):


### PR DESCRIPTION
## Description

When testing a workflow using this library, I was getting the following warning:
```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```

This PR attempts to resolve that by updating the usages of the class-based `config` in Pydantic dataclasses.