### PR TITLE
[CSS-20507]: Fix token refresh logic on client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "temporal-lib-py"
-version = "1.8.6"
+version = "1.8.7"
 description = "A wrapper library for candid-based temporal authentication"
 authors = ["gtato"]
 readme = "README.md"

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -81,15 +81,41 @@ class Client:
         # Cancel the background reconnect task if it exists
         if self._reconnect_task:
             self._reconnect_task.cancel()
-            del self._reconnect_task
+            self._reconnect_task = None
 
-        del self._client
-        del self._runtime
+        if hasattr(self, "_client"):
+            del self._client
+        if hasattr(self, "_runtime"):
+            del self._runtime
 
     @classmethod
     def instance(self) -> Optional[TemporalClient]:
         """Returns the underlying TemporalClient instance, if it exists."""
         return self._client
+
+    @classmethod
+    async def _get_auth_headers(self, auth: AuthOptions) -> Mapping[str, str]:
+        auth_header_provider = AuthHeaderProvider(auth)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, auth_header_provider.get_headers)
+
+    @classmethod
+    async def _cancel_reconnect_task(self) -> None:
+        task = self._reconnect_task
+        self._reconnect_task = None
+        self._is_stop_token_refresh = True
+        if not task or task.done():
+            return
+
+        try:
+            current_loop = asyncio.get_running_loop()
+            task_loop = task.get_loop()
+        except RuntimeError:
+            return
+
+        if task_loop is current_loop and not task_loop.is_closed():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     @classmethod
     async def reconnect_loop(self):
@@ -146,6 +172,9 @@ class Client:
         :param runtime: pass through parameter to `Client.connect()`
         :return: temporal client used to send or retrieve tasks
         """
+        await self._cancel_reconnect_task()
+        self._is_stop_token_refresh = False
+
         # Store the passed connection parameters for reconnection purposes
         self._client_opts = client_opt
         self._data_converter = data_converter
@@ -207,10 +236,9 @@ class Client:
     async def _reconnect(self):
         # Refresh the auth headers before reconnecting
         if self._client_opts.auth:
-            auth_header_provider = AuthHeaderProvider(self._client_opts.auth)
             self._client.rpc_metadata = {
                 **self._client.rpc_metadata,
-                **auth_header_provider.get_headers(),
+                **await self._get_auth_headers(self._client_opts.auth),
             }
 
         logging.debug("Testing Temporal server connection")

--- a/temporallib/client/client.py
+++ b/temporallib/client/client.py
@@ -191,8 +191,7 @@ class Client:
         self._keep_alive_config = keep_alive_config
 
         if client_opt.auth:
-            auth_header_provider = AuthHeaderProvider(client_opt.auth)
-            self._rpc_metadata.update(auth_header_provider.get_headers())
+            self._rpc_metadata.update(await self._get_auth_headers(client_opt.auth))
 
         if client_opt.encryption and client_opt.encryption.key:
             encryption_codec = EncryptionPayloadCodec(client_opt.encryption.key)

--- a/tests/connection/test_connection.py
+++ b/tests/connection/test_connection.py
@@ -21,6 +21,12 @@ async def mock_connect(_):
     return MagicMock()
 
 
+@pytest.fixture(autouse=True)
+async def cleanup_client_reconnect_task():
+    yield
+    await Client._cancel_reconnect_task()
+
+
 @pytest.mark.asyncio
 async def test_connect_candid(monkeypatch):
     monkeypatch.setattr(requests, "get", mock_get_macaroon)

--- a/tests/connection/test_connection.py
+++ b/tests/connection/test_connection.py
@@ -1,9 +1,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-import requests
-from google.oauth2 import service_account
-from macaroonbakery import bakery
 from temporalio.service import ServiceClient
 
 from temporallib.auth import (
@@ -14,23 +11,30 @@ from temporallib.auth import (
 )
 from temporallib.client import Client, Options
 from temporallib.encryption import EncryptionOptions, EncryptionPayloadCodec
-from tests.auth.test_auth import mock_discharge_all, mock_get_macaroon, mock_get_token
 
 
 async def mock_connect(_):
     return MagicMock()
 
 
+async def mock_get_auth_headers(auth):
+    return {"authorization": f"Bearer {auth.provider}"}
+
+
+async def mock_reconnect_loop():
+    pass
+
+
 @pytest.fixture(autouse=True)
-async def cleanup_client_reconnect_task():
+async def cleanup_client_reconnect_task(monkeypatch):
+    monkeypatch.setattr(Client, "reconnect_loop", mock_reconnect_loop)
     yield
     await Client._cancel_reconnect_task()
 
 
 @pytest.mark.asyncio
 async def test_connect_candid(monkeypatch):
-    monkeypatch.setattr(requests, "get", mock_get_macaroon)
-    monkeypatch.setattr(bakery, "discharge_all", mock_discharge_all)
+    monkeypatch.setattr(Client, "_get_auth_headers", mock_get_auth_headers)
     monkeypatch.setattr(ServiceClient, "connect", mock_connect)
     opts = Options(
         host="test",
@@ -77,8 +81,7 @@ async def test_connect_candid_env_variables(monkeypatch):
     )
     monkeypatch.setenv("TEMPORAL_TLS_ROOT_CAS", "certificate")
 
-    monkeypatch.setattr(requests, "get", mock_get_macaroon)
-    monkeypatch.setattr(bakery, "discharge_all", mock_discharge_all)
+    monkeypatch.setattr(Client, "_get_auth_headers", mock_get_auth_headers)
     monkeypatch.setattr(ServiceClient, "connect", mock_connect)
 
     opts = Options(
@@ -95,9 +98,7 @@ async def test_connect_candid_env_variables(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_connect_google(monkeypatch):
-    monkeypatch.setattr(
-        service_account.Credentials, "from_service_account_info", mock_get_token
-    )
+    monkeypatch.setattr(Client, "_get_auth_headers", mock_get_auth_headers)
     monkeypatch.setattr(ServiceClient, "connect", mock_connect)
     opts = Options(
         host="test",
@@ -157,9 +158,7 @@ async def test_connect_google_env_variables(monkeypatch):
     )
     monkeypatch.setenv("TEMPORAL_TLS_ROOT_CAS", "certificate")
 
-    monkeypatch.setattr(
-        service_account.Credentials, "from_service_account_info", mock_get_token
-    )
+    monkeypatch.setattr(Client, "_get_auth_headers", mock_get_auth_headers)
     monkeypatch.setattr(ServiceClient, "connect", mock_connect)
 
     opts = Options(

--- a/tests/connection/test_reconnect.py
+++ b/tests/connection/test_reconnect.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from temporallib.auth import AuthHeaderProvider, AuthOptions, GoogleAuthOptions
+from temporallib.client import Client, Options
+
+
+class FakeTemporalClient:
+    def __init__(self):
+        self.rpc_metadata = {}
+        self.count_workflows_calls = 0
+
+    async def count_workflows(self):
+        self.count_workflows_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_reconnect_token_refresh_does_not_block_event_loop(monkeypatch):
+    refresh_started = threading.Event()
+    heartbeat_ticks = []
+
+    def slow_get_headers(self):
+        refresh_started.set()
+        time.sleep(0.4)
+        return {"authorization": "Bearer refreshed-token"}
+
+    async def heartbeat():
+        while not refresh_started.is_set():
+            await asyncio.sleep(0.01)
+
+        while refresh_started.is_set():
+            heartbeat_ticks.append(time.monotonic())
+            await asyncio.sleep(0.05)
+
+    monkeypatch.setattr(AuthHeaderProvider, "get_headers", slow_get_headers)
+    Client._client = FakeTemporalClient()
+    Client._client_opts = Options(
+        host="test",
+        namespace="default",
+        auth=AuthOptions(
+            provider="google",
+            config=GoogleAuthOptions(
+                project_id="test",
+                private_key_id="test",
+                private_key="test",
+                client_email="test@example.com",
+                client_id="test",
+            ),
+        ),
+    )
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    await Client._reconnect()
+    refresh_started.clear()
+    heartbeat_task.cancel()
+    await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+    assert Client._client.rpc_metadata["authorization"] == "Bearer refreshed-token"
+    assert Client._client.count_workflows_calls == 1
+    assert len(heartbeat_ticks) >= 2


### PR DESCRIPTION
## Description

This PR fixes a worker hang scenario caused by synchronous auth token refresh running inside the async reconnect loop.

`AuthHeaderProvider.get_headers()` can perform blocking network I/O for Google or Candid auth. Previously, `_reconnect()` called it directly from the event loop, so a slow or stuck token refresh could freeze async worker progress while the reconnect loop continued to emit refresh-related logs.

Changes:

- Runs reconnect token refresh through `run_in_executor()` so blocking auth I/O does not block the event loop.
- Cancels any existing reconnect task before creating a new client connection.
- Makes `disconnect()` more defensive when clearing _client, _runtime, and _reconnect_task.

Fixes: [CSS-20507](https://warthogs.atlassian.net/browse/CSS-20507)

## Engineering checklist
_Check only items that apply_

- [ ] Documentation updated
- [x] Have tested the workflow works as expected

## Notes for code reviewers

Note: this lib could probably make use of some integration tests that spin up a local Temporal server and run some workflows against it for confirmation, but this is outside of scope of this PR. I tested the changes on some local scripts.

[CSS-20507]: https://warthogs.atlassian.net/browse/CSS-20507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ